### PR TITLE
Prevent js error when plugin not initialized and toggle or destroy is…

### DIFF
--- a/js/jquery.emojipicker.js
+++ b/js/jquery.emojipicker.js
@@ -409,14 +409,16 @@
     if (typeof options === 'string') {
       this.each(function() {
         var plugin = $.data( this, pluginName );
-        switch(options) {
-          case 'toggle':
-            plugin.iconClicked();
-            break;
-          case 'destroy':
-            plugin.destroyPicker();
-            break;
-        }
+	if(plugin) {
+	    switch(options) {
+                case 'toggle':
+	            plugin.iconClicked();
+                break;
+	        case 'destroy':
+                    plugin.destroyPicker();
+                break;
+            }
+	}
       });
       return this;
     }


### PR DESCRIPTION
… called - useful for situations where the user may cancel or submit input while the emoji dialog is open